### PR TITLE
Adds destroy comment feature

### DIFF
--- a/app/controllers/talkie/comments_controller.rb
+++ b/app/controllers/talkie/comments_controller.rb
@@ -1,7 +1,7 @@
 module Talkie
   class CommentsController < ::ApplicationController
-    before_action :set_user, only: [:create]
-    before_action :ensure_authenticated_user
+    before_action :set_user, :ensure_authenticated_user
+    before_action :set_comment, :correct_user!, only: [:destroy]
 
     def create
       @comment = Talkie::Comment.new(comment_params)
@@ -18,10 +18,23 @@ module Talkie
       end
     end
 
+    def destroy
+      @comment.destroy
+      redirect_to @comment.commentable
+    end
+
     private
 
     def comment_params
       params.require(:comment).permit(:body, :commentable_id, :commentable_type)
+    end
+
+    def correct_user!
+      redirect_back fallback_location: root_path, status: :unauthorized unless @user.owns_comment?(@comment)
+    end
+
+    def set_comment
+      @comment = Talkie::Comment.find(params[:id])
     end
 
     def set_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Talkie::Engine.routes.draw do
-  resources :comments, only: [:create]
+  resources :comments, only: [:create, :destroy]
 end

--- a/lib/talkie/acts_as_talker.rb
+++ b/lib/talkie/acts_as_talker.rb
@@ -12,6 +12,10 @@ module Talkie
           has_many :comments, as: :creator,
                               class_name: 'Talkie::Comment',
                               inverse_of: :creator
+
+          def owns_comment?(comment)
+            self == comment.creator
+          end
         end
       end
 

--- a/spec/controllers/talkie/comments_controller_spec.rb
+++ b/spec/controllers/talkie/comments_controller_spec.rb
@@ -50,6 +50,45 @@ RSpec.describe Talkie::CommentsController, type: :controller do
                                            commentable_id: commentable.id } } }.to change { Talkie::Comment.count }.by(1)
       end
     end
+  end
 
+  describe "#destroy" do
+    let!(:comment) { Talkie::Comment.create(body: "A sample body", commentable: commentable, creator: user) }
+
+    context "when there is no user logged in" do
+      before do
+        sign_out
+      end
+
+      it "won't delete the comment" do
+        delete :destroy, params: { id: comment.id }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the user is logged in" do
+      before do
+        sign_in user
+      end
+
+      context "and created the comment" do
+        it "deletes the comment" do
+          expect { delete :destroy, params: { id: comment.id } }.to change { Talkie::Comment.count }.by(-1)
+        end
+      end
+
+      context "and did not created the comment" do
+        it "won't delete the comment" do
+          another_user_comment = Talkie::Comment.create(body: "A sample body",
+                                                commentable: commentable,
+                                                creator: DummyUser.create)
+
+          delete :destroy, params: { id: another_user_comment.id }
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
   end
 end

--- a/spec/models/talkie/comment_spec.rb
+++ b/spec/models/talkie/comment_spec.rb
@@ -3,6 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Talkie::Comment, type: :model do
+  let(:user) { DummyUser.new }
+  let(:commentable) { DummyCommentable.new }
+
   it { is_expected.to respond_to(:body) }
   it { is_expected.to validate_presence_of(:body) }
   it { is_expected.to validate_presence_of(:creator) }
@@ -10,4 +13,24 @@ RSpec.describe Talkie::Comment, type: :model do
 
   it { is_expected.to belong_to(:creator).inverse_of(:comments) }
   it { is_expected.to belong_to(:commentable).inverse_of(:comments) }
+
+  describe "#owns_comment?" do
+    before do
+      @comment = Talkie::Comment.new(body: "A sample body",
+                                     commentable: commentable,
+                                     creator: user)
+    end
+
+    context "when the comment was created by the talker" do
+      it "will return true" do
+        expect(user.owns_comment?(@comment)).to be_truthy
+      end
+    end
+    context "when the comment was not created by the talker" do
+      it "will return false" do
+        other_user = DummyUser.new
+        expect(other_user.owns_comment?(@comment)).to be_falsy
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

* Adds `owns_comment?` method for the talker
* Adds `destroy` action to the comments controller